### PR TITLE
Social media crawlers redirect

### DIFF
--- a/web/.htaccess
+++ b/web/.htaccess
@@ -2,6 +2,10 @@
 <ifModule mod_rewrite.c>
 	RewriteEngine On
 
+	# allow social media crawlers to work by redirecting them to a server-rendered static version on the page
+	RewriteCond %{HTTP_USER_AGENT} (facebookexternalhit/[0-9]|Twitterbot)
+	RewriteRule highlight/(\d*)$ http://api.sc2hl.com/static/highlight/$1 [P]
+
 	RewriteCond %{REQUEST_FILENAME} !-f
 	RewriteCond %{REQUEST_FILENAME} !-d
 	RewriteCond %{REQUEST_URI} !index


### PR DESCRIPTION
Redirect facebook and twitter crawlers to the static highlight page
